### PR TITLE
only publish docs in the mainline repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ script:
 jobs:
     include:
         - stage: Publish docs
-          if: type = push AND branch = master
+          if: type = push AND branch = master AND fork = false
           script: travis/publishDocs.sh


### PR DESCRIPTION
Trying to publish docs in a repo that doesn't have the GH_TOKEN set causes the build to fail. I think it should be fair to assume that forks do not want to publish docs.

Alternatively the check could be `env(GH_TOKEN) != ""` or similar.